### PR TITLE
Fix markup for Video Production tutorial

### DIFF
--- a/resources/tutorials/videoproduction/index.md
+++ b/resources/tutorials/videoproduction/index.md
@@ -23,14 +23,20 @@ There are two types of footage that you'll shoot when you're taking footage for 
 ### Making Videos for the Audience
 Generally, videos for web should be short and concise.  Within the first 30 seconds, you should get the attention of your audience, and from then on you need to keep the video interesting.  
 
-<div markdown="1" class="row">
-<div class="span4">
+<div class="row">
+<div markdown="1" class="span4">
 ![A-roll](/img/tutorials/videoproduction/unger.png)
-<div style="text-align: center">*A-roll*</div>
+
+<div markdown="1" style="text-align: center">
+*A-roll*
 </div>
-<div class="span4 offset1">
+</div>
+<div markdown="1" class="span4 offset1">
 ![B-roll](/img/tutorials/videoproduction/field.png)
-<div style="text-align: center">*B-roll*</div>
+
+<div markdown="1" style="text-align: center">
+*B-roll*
+</div>
 </div>
 </div>
 


### PR DESCRIPTION
Looks like this was another bug caused by the switch to kramdown. The inner divs now all need to set `markdown="1"`, and kramdown appears to be more strict with whitespace.

Note: The blank lines after the images are required for the captions to be rendered properly.
