### PR TITLE
Fix bad selector in sponsor button handler.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,7 @@ function()
   $(".become-sponsor").click(
   function()
   {
-    var offset = $("#get_involved").offset();
+    var offset = $("#get-involved").offset();
     var heightOffset;
     if ($(window).width() > 767) {
         heightOffset = offset.top - $(".navbar-fixed-top").height() - 10;


### PR DESCRIPTION
This also seems to be a subtle difference between kramdown and Maruku.
Maruku appears to generate header ids using underscores, and kramdown
hyphens. This selector depends on the automatically generated id, which
unfortunately makes it susceptible to breakage.

However, functionality exists in kramdown (and has existed in Maruku) to
explicitly specify the id of a header. This might be worth implementing
in the interest of robustifying this code.

http://kramdown.gettalong.org/syntax.html#specifying-a-header-id
