### PR TITLE
Load disqus count script securely

### DIFF
--- a/_includes/disqus-count.html
+++ b/_includes/disqus-count.html
@@ -5,7 +5,7 @@ var disqus_shortname = 'stuypulse';
 (function () {
 var s = document.createElement('script'); s.async = true;
 s.type = 'text/javascript';
-s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+s.src = '//' + disqus_shortname + '.disqus.com/count.js';
 (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
 }());
 </script>


### PR DESCRIPTION
Fixes mixed content warnings when the site is served HTTPS.

`Mixed Content: The page at 'https://stuypulse.com/' was loaded over HTTPS, but requested an insecure script 'http://stuypulse.disqus.com/count.js'. This request has been blocked; the content must be served over HTTPS.`